### PR TITLE
Implement hotels recommendation endpoint using the recommendationHelpers

### DIFF
--- a/server/routes/recommendationRouter/hotelsRouter.js
+++ b/server/routes/recommendationRouter/hotelsRouter.js
@@ -1,9 +1,7 @@
 import express from 'express';
 import { authenticateToken } from '../authMiddleware.js';
 import { PrismaClient } from '@prisma/client';
-import { calculateOverallScore, budgetTierToPriceRange } from '../../utils/recommendationHelpers.js';
-import { getFallbackItems } from '../../utils/fallback.js';
-import { normalizeCity } from '../../utils/normalize.js';
+import { recommendForCategory } from '../../utils/recommendationCategory.js';
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -14,58 +12,21 @@ router.post('/', authenticateToken, async (req, res) => {
 
     try {
         // Get user preferences from database
-        let userPreferences = await prisma.userPreference.findUnique({
-            where: {userId},
-        });
-        if (!userPreferences) {
-            return res.status(404).json({message: 'User preferences not found'});
-        }
-        // destructure needed preferences
-        const {defaultCity, budgetTier } = userPreferences;
-        const userCity = normalizeCity(defaultCity);
-        if (!userCity) {
-            return res.status(400).json({message: 'Invalid city'});
-        }
-        // check if budget tier maps to a price range
-        if (!budgetTierToPriceRange[budgetTier]) {
-            return res.status(400).json({message: 'Invalid budget tier'});
-        }
-        // create filters for city and price range
-        const cityFilter = { equals: userCity, mode: 'insensitive' };
-        const priceRangeFilter = { gte: budgetTierToPriceRange[budgetTier].min };
-        if (Number.isFinite(budgetTierToPriceRange[budgetTier].max)) {
-            priceRangeFilter.lte = budgetTierToPriceRange[budgetTier].max;
-        }
-        // initialize find options for query to get top 100 hotels by rating in descending order
-        const findOptions = {
-            orderBy: { rating: 'desc' }, take: 100
-        };
-        const hotels = await prisma.hotel.findMany({
-            where: {
-                city: cityFilter,
-                price: priceRangeFilter
-            },
-            ...findOptions
-        })
-
-        const maxResultPerCategory = 10;
-        const scoredHotels = hotels.map(item =>
-            ({ ...item, categoryType: 'hotel', score: calculateOverallScore(item, userPreferences, 'hotel') }));
-
-        // Sort hotels descending by score and take the top 10
-        let sortedHotels = scoredHotels.sort((a, b) => b.score - a.score).slice(0, maxResultPerCategory);
-
-        // If there are less than 10 hotels, fill the rest with fallback items
-        if (sortedHotels.length < maxResultPerCategory) {
-            const fallbackItems = await getFallbackItems(userCity,'hotel', maxResultPerCategory - sortedHotels.length);
-            sortedHotels = [...sortedHotels, ...fallbackItems];
-        }
-
-        return res.status(200).json({hotels: sortedHotels});
-    } catch (error) {
-        console.error(error);
-        return res.status(500).json({message: 'Internal server error'});
+        const userPreferences = await prisma.userPreference.findUnique({
+      where: { userId },
+    });
+    if (!userPreferences) {
+      return res.status(404).json({ message: 'User preferences not found' });
     }
+    const hotels = await recommendForCategory('hotel', userPreferences);
+
+    return res.status(200).json({ hotels });
+  } catch (err) {
+    console.error('Hotel recommendation error', err);
+    return res
+      .status(500)
+      .json({ message: 'Internal server error' });
+  }
 });
 
 export default router;


### PR DESCRIPTION
### Description
This PR adds the hotels recommendation endpoint and wires it under the top‑level /recommendation router:

**What this pull request is doing:**
- In this Pr I posted the hotels with the top weighted score following the user preference
- Fetches user preferences (and optional weight overrides) via Prisma
- Normalizes and validates the user’s default city and budget tier
- Queries up to 100 matching hotels by city & price range
- Scores each hotel using calculateOverallScore() from utils/recommendationHelpers.js
- Sorts by score, picks the top 10, and fills in “fallback” hotels if fewer than 10
- Finally I mount the hotelsRouter at /recommendation/hotels in the main recommendationRouter.js

**What will be done in later PRs (not included here):**
- Implement the endpoints for restaurants and things-to-do
- Configure the main recommendation endpoint to aggregate results from all three sub‑routers
- Update my client‑side components to consume the /recommendation/hotels route

### Milestones
- Modularization & Cleanup (this PR)
- Extract and reuse shared helpers (normalizeCity, scoring, fallback)
- Added hotels‑specific router
- Validate weight overrides and fallback logic



