### PR TITLE
Things to do router

### DIFF
--- a/server/routes/recommendationRouter/thingsToDoRouter.js
+++ b/server/routes/recommendationRouter/thingsToDoRouter.js
@@ -41,19 +41,19 @@ router.post('/', authenticateToken, async (req, res) => {
                 city: cityFilter,
                 ...(activityCategory && {category: {contains: activityCategory, mode: 'insensitive'}})
             },  ...findOptions
-        })
+        });
 
         // recommend top 10 things to do in the given city and activity category based on user preferences
         const maxResultPerCategory = 10;
         const scoredThingsToDo = thingsToDo.map(item => ({
             ...item,
-            categoryType: "thingsToDo",
-            score: calculateOverallScore(item, userPreferences, "thingsToDo")
+            categoryType: 'thingsToDo',
+            score: calculateOverallScore(item, userPreferences, 'thingsToDo')
         }));
         let sortedThingsToDo = scoredThingsToDo.sort((a, b) => b.score - a.score).slice(0, maxResultPerCategory);
         // if less than 10 results, add fallback items
         if (sortedThingsToDo.length < maxResultPerCategory) {
-            const fallbackItems = await getFallbackItems(userCity, "thingsToDo", maxResultPerCategory - sortedThingsToDo.length);
+            const fallbackItems = await getFallbackItems(userCity, 'thingsToDo', maxResultPerCategory - sortedThingsToDo.length);
             sortedThingsToDo = [...sortedThingsToDo, ...fallbackItems];
         }
         return res.status(200).json( {thingsToDo: sortedThingsToDo});

--- a/server/routes/recommendationRouter/thingsToDoRouter.js
+++ b/server/routes/recommendationRouter/thingsToDoRouter.js
@@ -21,9 +21,6 @@ router.post('/', authenticateToken, async (req, res) => {
         if (!userPreferences) {
             return res.status(404).json({message: 'User preferences not found'});
         }
-        if (weights) {
-            userPreferences = {...userPreferences, ...weights};
-        }
         // destructure user preferences for city and activity category
         const {defaultCity, activityCategory } = userPreferences;
         const userCity = normalizeCity(defaultCity);

--- a/server/routes/recommendationRouter/thingsToDoRouter.js
+++ b/server/routes/recommendationRouter/thingsToDoRouter.js
@@ -1,0 +1,66 @@
+import express from 'express';
+import { authenticateToken } from '../authMiddleware.js';
+import { PrismaClient } from '@prisma/client';
+import { calculateOverallScore } from '../../utils/recommendationHelpers.js';
+import { getFallbackItems } from '../../utils/fallback.js';
+import { normalizeCity } from '../../utils/normalize.js';
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+// POST things-to-do recommendation route handler for a given city and activity category
+router.post('/', authenticateToken, async (req, res) => {
+    const userId = req.user.userId;
+    const {weights} = req.body;
+
+    try {
+        // Get user preferences
+        let userPreferences = await prisma.userPreference.findUnique({
+            where: {userId},
+        });
+        if (!userPreferences) {
+            return res.status(404).json({message: 'User preferences not found'});
+        }
+        if (weights) {
+            userPreferences = {...userPreferences, ...weights};
+        }
+        // destructure user preferences for city and activity category
+        const {defaultCity, activityCategory } = userPreferences;
+        const userCity = normalizeCity(defaultCity);
+        if (!userCity) {
+            return res.status(400).json({message: 'Invalid city'});
+        }
+        // create filters for city and activity category
+        const cityFilter = { equals: userCity, mode: 'insensitive' };
+        const findOptions = {
+            orderBy: { rating: 'desc' }, take: 100
+        };
+        // find things to do in the given city and activity category with the highest rating
+        const thingsToDo = await prisma.thingsToDo.findMany({
+            where: {
+                city: cityFilter,
+                ...(activityCategory && {category: {contains: activityCategory, mode: 'insensitive'}})
+            },  ...findOptions
+        })
+
+        // recommend top 10 things to do in the given city and activity category based on user preferences
+        const maxResultPerCategory = 10;
+        const scoredThingsToDo = thingsToDo.map(item => ({
+            ...item,
+            categoryType: "thingsToDo",
+            score: calculateOverallScore(item, userPreferences, "thingsToDo")
+        }));
+        let sortedThingsToDo = scoredThingsToDo.sort((a, b) => b.score - a.score).slice(0, maxResultPerCategory);
+        // if less than 10 results, add fallback items
+        if (sortedThingsToDo.length < maxResultPerCategory) {
+            const fallbackItems = await getFallbackItems(userCity, "thingsToDo", maxResultPerCategory - sortedThingsToDo.length);
+            sortedThingsToDo = [...sortedThingsToDo, ...fallbackItems];
+        }
+        return res.status(200).json( {thingsToDo: sortedThingsToDo});
+    }   catch (error) {
+            console.error('ThingsToDo recommendation error', error);
+        return res.status(500).json({message: 'Internal server error'});
+    }
+});
+
+export default router;

--- a/server/routes/recommendationRouter/thingsToDoRouter.js
+++ b/server/routes/recommendationRouter/thingsToDoRouter.js
@@ -1,9 +1,7 @@
 import express from 'express';
 import { authenticateToken } from '../authMiddleware.js';
 import { PrismaClient } from '@prisma/client';
-import { calculateOverallScore } from '../../utils/recommendationHelpers.js';
-import { getFallbackItems } from '../../utils/fallback.js';
-import { normalizeCity } from '../../utils/normalize.js';
+import { recommendForCategory } from '../../utils/recommendationCategory.js';
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -13,50 +11,22 @@ router.post('/', authenticateToken, async (req, res) => {
     const userId = req.user.userId;
 
     try {
-        // Get user preferences
-        let userPreferences = await prisma.userPreference.findUnique({
-            where: {userId},
-        });
-        if (!userPreferences) {
-            return res.status(404).json({message: 'User preferences not found'});
-        }
-        // destructure user preferences for city and activity category
-        const {defaultCity, activityCategory } = userPreferences;
-        const userCity = normalizeCity(defaultCity);
-        if (!userCity) {
-            return res.status(400).json({message: 'Invalid city'});
-        }
-        // create filters for city and activity category
-        const cityFilter = { equals: userCity, mode: 'insensitive' };
-        const findOptions = {
-            orderBy: { rating: 'desc' }, take: 100
-        };
-        // find things to do in the given city and activity category with the highest rating
-        const thingsToDo = await prisma.thingsToDo.findMany({
-            where: {
-                city: cityFilter,
-                ...(activityCategory && {category: {contains: activityCategory, mode: 'insensitive'}})
-            },  ...findOptions
-        });
-
-        // recommend top 10 things to do in the given city and activity category based on user preferences
-        const maxResultPerCategory = 10;
-        const scoredThingsToDo = thingsToDo.map(item => ({
-            ...item,
-            categoryType: 'thingsToDo',
-            score: calculateOverallScore(item, userPreferences, 'thingsToDo')
-        }));
-        let sortedThingsToDo = scoredThingsToDo.sort((a, b) => b.score - a.score).slice(0, maxResultPerCategory);
-        // if less than 10 results, add fallback items
-        if (sortedThingsToDo.length < maxResultPerCategory) {
-            const fallbackItems = await getFallbackItems(userCity, 'thingsToDo', maxResultPerCategory - sortedThingsToDo.length);
-            sortedThingsToDo = [...sortedThingsToDo, ...fallbackItems];
-        }
-        return res.status(200).json( {thingsToDo: sortedThingsToDo});
-    }   catch (error) {
-            console.error('ThingsToDo recommendation error', error);
-        return res.status(500).json({message: 'Internal server error'});
+    // load the user’s preferences
+    const userPreferences = await prisma.userPreference.findUnique({
+      where: { userId },
+    });
+    if (!userPreferences) {
+      return res.status(404).json({ message: 'User preferences not found' });
     }
+
+    // delegate to the shared helper
+    const thingsToDo = await recommendForCategory('thingsToDo', userPreferences);
+    return res.status(200).json({ thingsToDo });
+
+  } catch (err) {
+    console.error('ThingsToDo recommendation error', err);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
 });
 
 export default router;

--- a/server/routes/recommendationRouter/thingsToDoRouter.js
+++ b/server/routes/recommendationRouter/thingsToDoRouter.js
@@ -11,7 +11,6 @@ const router = express.Router();
 // POST things-to-do recommendation route handler for a given city and activity category
 router.post('/', authenticateToken, async (req, res) => {
     const userId = req.user.userId;
-    const {weights} = req.body;
 
     try {
         // Get user preferences


### PR DESCRIPTION
### Description
- In this PR implemented the thingsToDo recommendation endpoint and wires it under the top‑level recommendation router:

**What this pull request is doing:**

- In this Pr I post the things-to-do with the top weighted score following the user preference on activity category
- Fetches user preferences
- Normalizes and validates the user’s default city and type of activities interested in
- Queries up to 100 matching activity category and further sort by rating 
- Scores each things-to-do using calculateOverallScore() from utils/recommendationHelpers.js
- Sorts by score, picks the top 10, and fills in “fallback” restaurants if fewer than 10
- Finally I mount the thingsToDoRouter at /recommendation/thingsToDo in the main recommendationRouter.js

**What will be done in later PRs (not included here):**

- Implement the endpoints for things-to-do
- Configure the main recommendation endpoint to aggregate results from all three sub‑routers
- Update my client‑side components to consume the /recommendation/things-to-do route

**Milestones**
- Modularization & Cleanup (this PR)
- Extract and reuse shared helpers (normalizeCity, scoring, fallback)
- Added thingsToDo‑specific router
- Validate weight overrides and fallback logic.