### PR TITLE
created 3 components to use ListPage and DetailCard

### DIFF
--- a/client/client/src/Pages/HotelPage.jsx
+++ b/client/client/src/Pages/HotelPage.jsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import ListPage from '../Components/ListPage';
+
+export default function HotelPage() {
+    const [weights, setWeights] = useState({
+        hotelPriceWeight: 0.4,
+        hotelRatingWeight: 0.3,
+        hotelReviewWeight: 0.3,
+    });
+
+    const handleWeightChange = ({ target: { name, value } }) => {
+        setWeights( prevWeights => ({
+            ...prevWeights, [name]: parseFloat(value)
+        }));
+    };
+
+    return (
+        <ListPage
+            endpoint='hotels'
+            label='Hotel'
+            showPrice={true}
+            weights={weights}
+            onWeightChange={handleWeightChange}
+        />
+    );
+}

--- a/client/client/src/Pages/RestaurantPage.jsx
+++ b/client/client/src/Pages/RestaurantPage.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import ListPage from '../Components/ListPage';
+
+export default function HotelPage() {
+    const [weights, setWeights] = useState({
+        restaurantRatingWeight: 0.5,
+        restaurantReviewWeight: 0.5,
+    });
+
+    const handleWeightChange = ({ target: { name, value } }) => {
+        setWeights( prevWeights => ({
+            ...prevWeights, [name]: parseFloat(value)
+        }));
+    };
+
+    return (
+        <ListPage
+            endpoint='restaurants'
+            label='Restaurants'
+            showPrice={false}
+            weights={weights}
+            onWeightChange={handleWeightChange}
+        />
+    );
+}

--- a/client/client/src/Pages/ThingsToDoPage.jsx
+++ b/client/client/src/Pages/ThingsToDoPage.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import ListPage from '../Components/ListPage';
+
+export default function HotelPage() {
+    const [weights, setWeights] = useState({
+        thingsToDoRatingWeight: 0.5,
+        thingsToDoReviewWeight: 0.5,
+    });
+
+    const handleWeightChange = ({ target: { name, value } }) => {
+        setWeights( prevWeights => ({
+            ...prevWeights, [name]: parseFloat(value)
+        }));
+    };
+
+    return (
+        <ListPage
+            endpoint='things-to-do'
+            label='Attractions'
+            showPrice={false}
+            weights={weights}
+            onWeightChange={handleWeightChange}
+        />
+    );
+}


### PR DESCRIPTION
## Description
This PR wires the three list pages—Hotels, Restaurants, and Things To Do—into the app 

- Manages its own weight state via `useState`
- Delegates rendering and data‑fetching to `ListPage`
- Passes the correct `endpoint`, `label`, and `showPrice` props 
- A state is used to track if the page is hotel and only then is it set to true for prices
