### PR TITLE
Page list

### DIFF
--- a/client/client/src/Components/ListPage.css
+++ b/client/client/src/Components/ListPage.css
@@ -1,0 +1,68 @@
+.itinerary-layout {
+  display: flex;
+  gap: 30px;
+  padding: 30px;
+  box-sizing: border-box;
+  margin-top: 80px;
+  min-height: calc(100vh - 80px);
+  background-color: #f0f4f8;
+  font-family: 'Open Sans', 'Gill Sans MT', 'Gill Sans', Corbel, Arial,
+    sans-serif;
+}
+
+.itinerary-sliders h2 {
+  font-size: 1.6rem;
+  font-weight: 600;
+  margin-bottom: 24px;
+  color: #1017a7;
+  border-bottom: 2px solid #2e65a9;
+  padding-bottom: 12px;
+  text-align: center;
+}
+
+.itinerary-sliders .error {
+  color: #dc3545;
+  font-size: 0.9rem;
+  margin-top: 16px;
+  padding: 10px 12px;
+  background-color: #fff5f5;
+  border-left: 4px solid #dc3545;
+  border-radius: 0 6px 6px 0;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.itinerary-results {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+itinerary-cards .ititinerary-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.itinerary-cards:empty::after {
+  content: 'No hotels found. Try adjusting your preferences.';
+  display: block;
+  text-align: center;
+  padding: 40px;
+  color: #6c757d;
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+  font-size: 1.1rem;
+  margin: 20px 0;
+}

--- a/client/client/src/Components/ListPage.jsx
+++ b/client/client/src/Components/ListPage.jsx
@@ -1,0 +1,72 @@
+import ItineraryTooltip from '../Components/ItineraryTooltip.jsx';
+import Header from '../Components/Header.jsx';
+import Spinner from '../Components/Spinner.jsx';
+import DetailCard from './DetailCard.jsx';
+import useListPage from '../Hook/ItineraryHook.js';
+import './ListPage.css';
+
+export default function ListPage({
+    endpoint,
+    label,
+    showPrice,
+    weights,
+    onWeightChange
+    }) {
+    const { items, loading } = useListPage(endpoint, weights);
+
+  return (
+    <div className='itinerary-layout'>
+      <aside className='itinerary-sliders'>
+        <h2>{label} Preferences</h2>
+        {Object.entries(weights).map(([key, val]) => (
+          <div key={key} className='slider-container'>
+            <label htmlFor={key}>
+              {key
+                .replace(/(hotel|restaurant|thingsToDo)?/i, '')
+                .replace(/([A-Z])/g, ' $1')
+                .trim()}
+            </label>
+            <input
+              type='range'
+              id={key}
+              name={key}
+              min='0'
+              max='1'
+              step='0.01'
+              value={val}
+              onChange={onWeightChange}
+            />
+            <span>{Math.round(val * 100)}%</span>
+          </div>
+        ))}
+      </aside>
+
+      <main className='itinerary-results'>
+        <Header />
+        <ItineraryTooltip />
+
+        {loading ? (
+          <Spinner size={80} overlay={true} text='Loading...' />
+        ) : (
+          <div className='itinerary-cards'>
+            {items.map((item, i) => (
+              <DetailCard
+                key={i}
+                label={label}
+                imageUrl={item.imageUrl}
+                name={item.name}
+                rating={item.rating}
+                reviewCount={item.reviewCount}
+                description={item.description}
+                city={item.city}
+                state={item.state}
+                price={item.price}
+                showPrice={showPrice}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/client/client/src/Hook/ItineraryHook.js
+++ b/client/client/src/Hook/ItineraryHook.js
@@ -1,0 +1,34 @@
+import { useState, useEffect, useRef } from 'react';
+import axios from 'axios';
+import BASE_URL from '/api';
+
+export default function useListPage(endpoint, weights) {
+    const [items, setItems] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const debounceRef = useRef(null);
+
+    useEffect(() => {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(fetchItems, 500);
+        return () => clearTimeout(debounceRef.current);
+    }, [weights]);
+
+    // fetch items from the server and update the state with the result
+    async function fetchItems() {
+        setLoading(true);
+        try {
+            const { data } = await axios.post(`${BASE_URL}/${endpoint}`,
+                { weights },
+                { withCredentials: true }
+            );
+            const list = data[endpoint];
+            setItems(Array.isArray(list) ? list : []);
+        } catch (err) {
+            console.error(`Error fetching ${endpoint}:`, err);
+            setItems([]);
+        }   finally {
+            setLoading(false);
+        }
+    }
+    return { items, loading };
+}


### PR DESCRIPTION
## Description
- This pull request introduces a new **ListPage** component and its associated **itineraryHook.js** hook to unify the way to render lists of hotels, restaurants, and attractions. Rather than duplicating the same layout, slider logic, API calls, and loading state in three separate pages, we now:

- **Encapsulate the data fetching and debounce behavior** in a single custom hook that takes an API endpoint and the user’s weight settings, then returns the fetched items and a loading flag.
- **Provide a reusable page wrapper** (`ListPage`) that renders:
  - A sidebar of preference sliders, generated dynamically from the weight keys
  - A top bar with our existing header and itinerary tooltip
  - A loading spinner overlay while data is being fetched
  - A grid of detail cards for each returned item, optionally showing a price field

**What Will be Done In Next PR**
- Simplify each individual page (HotelPage, RestaurantPage, ThingsToDoPage) down to just:
  1. Managing its own weight state via React’s `useState`
  2. Passing the correct `endpoint`, `label`, and `showPrice` flag into `ListPage`
  3. Providing a simple callback to update the weights when sliders move

By centralizing the API‑call logic and layout in two shared modules, I achieve to reduce boilerplate, eliminate redundant code, and ensure all three pages stay in sync if  sliders are tweaked.