### PR TITLE
Tool tip

### DIFF
--- a/client/client/src/Components/ItineraryTooltip.css
+++ b/client/client/src/Components/ItineraryTooltip.css
@@ -1,0 +1,126 @@
+.itinerary-tooltip-container {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  left: 350%;
+}
+
+.itinerary-text {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: white;
+  padding: 8px 16px;
+  border: 2px solid #2e65a9;
+  border-radius: 20px;
+  background-color: #1d4a73;
+  transition: all 0.3s ease;
+  display: inline-block;
+}
+
+.itinerary-tooltip-container:hover .itinerary-text {
+  background-color: #2e65a9;
+  color: white;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.itinerary-tooltip-content {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.95);
+  min-width: 250px;
+  background-color: white;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s ease;
+  z-index: 1000;
+  border-top: 4px solid #2e65a9;
+}
+
+.itinerary-tooltip-content::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0 10px 10px 10px;
+  border-style: solid;
+  border-color: transparent transparent #2e65a9 transparent;
+}
+
+.itinerary-tooltip-container:hover .itinerary-tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+}
+
+.itinerary-tooltip-content h3 {
+  margin: 0 0 12px;
+  color: #1d4a73;
+  font-size: 1.1rem;
+  text-align: center;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 8px;
+}
+
+.itinerary-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.itinerary-button {
+  padding: 10px;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+}
+
+.itinerary-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.hotel-button {
+  background-color: #2e65a9;
+}
+
+.hotel-button:hover {
+  background-color: #1d4a73;
+}
+
+.restaurant-button {
+  background-color: #e63946;
+}
+
+.restaurant-button:hover {
+  background-color: #c1121f;
+}
+
+.things-button {
+  background-color: #2a9d8f;
+}
+
+.things-button:hover {
+  background-color: #179f8f;
+}
+
+@media (max-width: 768px) {
+  .itinerary-tooltip-content {
+    min-width: 220px;
+  }
+
+  .itinerary-text {
+    font-size: 1rem;
+    padding: 6px 12px;
+  }
+}

--- a/client/client/src/Components/ItineraryTooltip.jsx
+++ b/client/client/src/Components/ItineraryTooltip.jsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import BASE_URL from '/api.js';
+import axios from 'axios';
+import './ItineraryTooltip.css';
+
+export default function ItineraryTooltip() {
+  const navigate = useNavigate();
+  const [hasPreferences, setHasPreferences] = useState(false);
+
+  // Check if user has preferences
+  useEffect(() => {
+    const checkPreferences = async () => {
+      try {
+        const { data } = await axios.get(`${BASE_URL}/preference`, {
+          withCredentials: true,
+        });
+        // If user has preferences, I set hasPreferences to true
+        setHasPreferences(
+          data &&
+            data.defaultCity &&
+            data.cuisine &&
+            data.budgetTier &&
+            data.activityCategory
+        );
+      } catch (err) {
+        console.error('Error checking preferences:', err);
+        setHasPreferences(false);
+      }
+    };
+
+    checkPreferences();
+  }, []);
+
+  const handleNavigation = (destination) => {
+    // If user doesn't have preferences, redirect to preferences page first
+    if (!hasPreferences) {
+      // Store the  destination to redirect after preferences are set
+      sessionStorage.setItem('redirectAfterPreferences', destination);
+      navigate('/preference');
+    } else {
+      // User has preferences, navigate to the destination
+      navigate(destination);
+    }
+  };
+
+  return (
+    <div className='itinerary-tooltip-container'>
+      <span className='itinerary-text'>Itinerary</span>
+      <div className='itinerary-tooltip-content'>
+        <h3>Enjoy Your Trip</h3>
+        <div className='itinerary-buttons'>
+          <button
+            onClick={() => handleNavigation('/hotels')}
+            className='itinerary-button hotel-button'
+          >
+            Hotels
+          </button>
+          <button
+            onClick={() => handleNavigation('/restaurants')}
+            className='itinerary-button restaurant-button'
+          >
+            Restaurants
+          </button>
+          <button
+            onClick={() => handleNavigation('/things-to-do')}
+            className='itinerary-button things-button'
+          >
+            Things to Do
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/client/src/Components/TooTip.jsx
+++ b/client/client/src/Components/TooTip.jsx
@@ -1,0 +1,14 @@
+import './ToolTip.css';
+
+export default function ToolTip({
+    text,
+    children,
+    position = 'top',
+}) {
+  return (
+    <div className={`tooltip-container tooltip-${position}`}>
+        {children}
+        <div className='tooltip-box'>{text}</div>
+    </div>
+  );
+}

--- a/client/client/src/Components/ToolTip.css
+++ b/client/client/src/Components/ToolTip.css
@@ -1,0 +1,65 @@
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+  margin: 0 0 0 4px;
+}
+
+.tooltip-box {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(10px) scale(0.95);
+  background-color: #145172;
+  color: #fff;
+  border-radius: 6px;
+  padding: 8px 12px;
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+  max-width: none;
+  font-size: 1.3rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+  box-shadow: 0 4px 12px rgba(99, 101, 105, 0.25);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.tooltip-box::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-style: solid;
+  border-color: #333 transparent transparent transparent;
+}
+
+.tooltip-container:hover .tooltip-box,
+.tooltip-container:focus-within .tooltip-box {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+  transition-delay: 0.1s;
+}
+
+.tooltip-container:focus .tooltip-box {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.tooltip-container.tooltip-bottom .tooltip-box {
+  bottom: auto;
+  top: calc(100% + 8px);
+  transform-origin: top center;
+}
+
+.tooltip-container.tooltip-bottom .tooltip-box::after {
+  top: -6px;
+  bottom: auto;
+  border-width: 0 6px 6px;
+  border-color: transparent transparent rgba(0,0,0,0.85);
+}


### PR DESCRIPTION
## Description
This pull request introduces the **`ItineraryTooltip`** component—a dynamic, context‑aware tooltip button that lets users jump directly to Hotels, Restaurants, or Things to Do, while ensuring first‑time visitors complete their preference setup first.

**What this PR Does**

1. **Preference Check on Mount**  
   - Uses a `useEffect` to call `GET /preference` as soon as the component mounts.  
   - Sets `hasPreferences` to `true` only if the user’s saved preferences include `defaultCity`, `cuisine`, `budgetTier`, and `activityCategory`.  

2. **Conditional Navigation Logic**  
   - The itinerary Tooltip exposes three buttons (“Hotels,” “Restaurants,” “Things to Do”) inside the tooltip content.  
   - Clicking a button invokes `handleNavigation(destination)`:  
    **If the user lacks preferences**, it  
    1. Stores the intended route (e.g. `/hotels`) in `sessionStorage.redirectAfterPreferences`.  
    2. Redirects them to `/preference` so they can fill out the setup form.  
    **If the user already has preferences**, it immediately navigates to the chosen page.

3. **Tooltip UI Structure**  
   - On hover on the itinerary button, it reveals a the itinerary-tooltip-content panel containing:   
     Three styled buttons, of itinerary recommendation for user
