### PR TITLE
Backend dynamic weights

### DIFF
--- a/server/routes/recommendationRouter/hotelsRouter.js
+++ b/server/routes/recommendationRouter/hotelsRouter.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { authenticateToken } from '../authMiddleware.js';
 import { PrismaClient } from '@prisma/client';
 import { recommendForCategory } from '../../utils/recommendationCategory.js';
+import { mergePreferences } from '../../../shared/mergePreferences.js';
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -18,7 +19,9 @@ router.post('/', authenticateToken, async (req, res) => {
     if (!userPreferences) {
       return res.status(404).json({ message: 'User preferences not found' });
     }
-    const hotels = await recommendForCategory('hotel', userPreferences);
+    // merge db preferences with client sent weights
+    const mergedPreferences = mergePreferences(userPreferences, req.body.weights);
+    const hotels = await recommendForCategory('hotel', mergedPreferences);
 
     return res.status(200).json({ hotels });
   } catch (err) {

--- a/server/routes/recommendationRouter/restaurantsRouter.js
+++ b/server/routes/recommendationRouter/restaurantsRouter.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { authenticateToken } from '../authMiddleware.js';
 import { PrismaClient } from '@prisma/client';
 import { recommendForCategory } from '../../utils/recommendationCategory.js';
+import { mergePreferences } from '../../../shared/mergePreferences.js';
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -18,9 +19,9 @@ router.post('/', authenticateToken, async (req, res) => {
     if (!userPreferences) {
       return res.status(404).json({ message: 'User preferences not found' });
     }
-
-    // delegate to the shared helper
-    const restaurants = await recommendForCategory('restaurant', userPreferences);
+     // merge db preferences with client sent weights
+    const mergedPreferences = mergePreferences(userPreferences, req.body.weights);
+    const restaurants = await recommendForCategory('restaurant', mergedPreferences);
     return res.status(200).json({ restaurants });
 
   } catch (err) {

--- a/server/routes/recommendationRouter/thingsToDoRouter.js
+++ b/server/routes/recommendationRouter/thingsToDoRouter.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { authenticateToken } from '../authMiddleware.js';
 import { PrismaClient } from '@prisma/client';
 import { recommendForCategory } from '../../utils/recommendationCategory.js';
+import { mergePreferences } from '../../../shared/mergePreferences.js';
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -18,9 +19,11 @@ router.post('/', authenticateToken, async (req, res) => {
     if (!userPreferences) {
       return res.status(404).json({ message: 'User preferences not found' });
     }
+     // merge db preferences with client sent weights
+    const mergedPreferences = mergePreferences(userPreferences, req.body.weights);
 
     // delegate to the shared helper
-    const thingsToDo = await recommendForCategory('thingsToDo', userPreferences);
+    const thingsToDo = await recommendForCategory('thingsToDo', mergedPreferences);
     return res.status(200).json({ thingsToDo });
 
   } catch (err) {

--- a/server/routes/userPreference.js
+++ b/server/routes/userPreference.js
@@ -1,6 +1,12 @@
 import express from 'express';
 import { authenticateToken } from '../routes/authMiddleware.js';
 import { PrismaClient } from '@prisma/client';
+import {
+  DEFAULT_MAIN_WEIGHTS,
+  DEFAULT_HOTEL_WEIGHTS,
+  DEFAULT_RESTAURANT_WEIGHTS,
+  DEFAULT_THINGS_TO_DO_WEIGHTS,
+} from '../../shared/WeightsConstants.mjs';
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -22,7 +28,28 @@ router.get('/', authenticateToken, async (req, res) => {
 
 // post a new preference for a new user on registration
 router.post('/', authenticateToken, async (req, res) => {
-  const { budgetTier, cuisine, activityCategory, defaultCity } = req.body;
+  const {
+    budgetTier,
+    cuisine,
+    activityCategory,
+    defaultCity,
+
+    cityWeight,
+    budgetWeight,
+    cuisineWeight,
+    activityWeight,
+
+    hotelPriceWeight,
+    hotelRatingWeight,
+    hotelReviewWeight,
+
+    restaurantRatingWeight,
+    restaurantReviewWeight,
+
+    thingsToDoRatingWeight,
+    thingsToDoReviewWeight,
+   } = req.body;
+
   try {
     // if there's no perefence for the user, create a new one
     const userPref = await prisma.userPreference.upsert({
@@ -33,6 +60,19 @@ router.post('/', authenticateToken, async (req, res) => {
         cuisine,
         activityCategory,
         defaultCity,
+
+        // set default weights if not provided
+        cityWeight: cityWeight || DEFAULT_MAIN_WEIGHTS.cityWeight,
+        budgetWeight: budgetWeight || DEFAULT_MAIN_WEIGHTS.budgetWeight,
+        cuisineWeight: cuisineWeight || DEFAULT_MAIN_WEIGHTS.cuisineWeight,
+        activityWeight: activityWeight || DEFAULT_MAIN_WEIGHTS.activityWeight,
+        hotelPriceWeight: hotelPriceWeight || DEFAULT_HOTEL_WEIGHTS.priceWeight,
+        hotelRatingWeight: hotelRatingWeight || DEFAULT_HOTEL_WEIGHTS.ratingWeight,
+        hotelReviewWeight: hotelReviewWeight || DEFAULT_HOTEL_WEIGHTS.reviewWeight,
+        restaurantRatingWeight: restaurantRatingWeight || DEFAULT_RESTAURANT_WEIGHTS.ratingWeight,
+        restaurantReviewWeight: restaurantReviewWeight || DEFAULT_RESTAURANT_WEIGHTS.reviewWeight,
+        thingsToDoRatingWeight: thingsToDoRatingWeight || DEFAULT_THINGS_TO_DO_WEIGHTS.ratingWeight,
+        thingsToDoReviewWeight: thingsToDoReviewWeight || DEFAULT_THINGS_TO_DO_WEIGHTS.reviewWeight,
       },
       // if there's a preference for the user, I'll update it
       update: {
@@ -40,6 +80,19 @@ router.post('/', authenticateToken, async (req, res) => {
         cuisine,
         activityCategory,
         defaultCity,
+
+        // update weights if provided
+        cityWeight: cityWeight || undefined,
+        budgetWeight: budgetWeight || undefined,
+        cuisineWeight: cuisineWeight || undefined,
+        activityWeight: activityWeight || undefined,
+        hotelPriceWeight: hotelPriceWeight || undefined,
+        hotelRatingWeight: hotelRatingWeight || undefined,
+        hotelReviewWeight: hotelReviewWeight || undefined,
+        restaurantRatingWeight: restaurantRatingWeight || undefined,
+        restaurantReviewWeight: restaurantReviewWeight || undefined,
+        thingsToDoRatingWeight: thingsToDoRatingWeight || undefined,
+        thingsToDoReviewWeight: thingsToDoReviewWeight || undefined,
       },
     });
     // return the updated preference

--- a/shared/WeightsConstants.mjs
+++ b/shared/WeightsConstants.mjs
@@ -1,0 +1,77 @@
+export const DEFAULT_MAIN_WEIGHTS = {
+  cityWeight: 0.4,
+  budgetWeight: 0.3,
+  cuisineWeight: 0.15,
+  activityWeight: 0.15,
+};
+
+export const DEFAULT_HOTEL_WEIGHTS = {
+  hotelPriceWeight: 0.4,
+  hotelRatingWeight: 0.3,
+  hotelReviewWeight: 0.3,
+};
+
+export const DEFAULT_RESTAURANT_WEIGHTS = {
+  restaurantRatingWeight: 0.5,
+  restaurantReviewWeight: 0.5,
+};
+
+export const DEFAULT_THINGS_TO_DO_WEIGHTS = {
+  thingsToDoRatingWeight: 0.5,
+  thingsToDoReviewWeight: 0.5,
+};
+
+export const BUDGET_TIERS = [
+  { value: '1', label: 'Standard (up to $50)' },
+  { value: '2', label: 'Moderate (up to $100)' },
+  { value: '3', label: 'Premium (up to $200)' },
+  { value: '4', label: 'Luxury (above $200)' },
+];
+
+export const CUISINE_OPTIONS = [
+  { value: 'american', label: 'American' },
+  { value: 'italian', label: 'Italian' },
+  { value: 'mexican', label: 'Mexican' },
+  { value: 'japanese', label: 'Japanese' },
+];
+
+export const ACTIVITY_CATEGORIES = [
+  { value: 'Adventure', label: 'Adventure' },
+  { value: 'Art', label: 'Art' },
+  { value: 'Culture', label: 'Culture' },
+  { value: 'Nightlife', label: 'Nightlife' },
+];
+
+export const SLIDER_GROUPS = [
+  {
+    title: 'Main Weights',
+    items: [
+      { key: 'cityWeight', label: 'City' },
+      { key: 'budgetWeight', label: 'Budget' },
+      { key: 'cuisineWeight', label: 'Cuisine' },
+      { key: 'activityWeight', label: 'Activity' },
+    ],
+  },
+  {
+    title: 'Hotel Weights',
+    items: [
+      { key: 'hotelPriceWeight', label: 'Price Closeness' },
+      { key: 'hotelRatingWeight', label: 'Rating' },
+      { key: 'hotelReviewWeight', label: 'Popularity' },
+    ],
+  },
+  {
+    title: 'Restaurant Weights',
+    items: [
+      { key: 'restaurantRatingWeight', label: 'Rating' },
+      { key: 'restaurantReviewWeight', label: 'Popularity' },
+    ],
+  },
+  {
+    title: 'Things To Do Weights',
+    items: [
+      { key: 'thingsToDoRatingWeight', label: 'Rating' },
+      { key: 'thingsToDoReviewWeight', label: 'Popularity' },
+    ],
+  },
+];

--- a/shared/mergePreferences.js
+++ b/shared/mergePreferences.js
@@ -1,0 +1,4 @@
+// shared/mergePreferences.js
+export function mergePreferences(userPreferences, bodyWeights = {}) {
+  return { ...userPreferences, ...bodyWeights };
+}


### PR DESCRIPTION
## Description
Added shared WeightsConstants.mjs for defaults and updated backend routers to use dynamic weights in recommendations.

### What is this PR doing
- Added WeightsConstants.mjs: Centralized defaults for main, hotel, restaurant, thingsToDo weights.
- I created a shared merge preference to merge current weights alongside side ones created when user interacted with the slider.
- Modified userPreference.js: Used shared constants for defaults, fixed 0 weight saving.

### Why?
- Enables dynamic weights from client in backend recommendations.
- DRY by sharing constants between client/server.

### Testing
- Tested POST /preference: Saves dynamic weights to DB.
- Tested POST /hotels: Uses weights for scoring, returns recommendations.

